### PR TITLE
Use mjolnir.grille to do the grid layout

### DIFF
--- a/mjolnir.7bits.mjomatic-0.1-1.rockspec
+++ b/mjolnir.7bits.mjomatic-0.1-1.rockspec
@@ -37,7 +37,7 @@ dependencies = {
   -- "mjolnir.fnutils",
   "mjolnir.screen",
   "mjolnir.alert",
-  "mjolnir.cmsj.appfinder"
+  "mjolnir.grille"
 }
 
 -- Build rules:

--- a/mjomatic.lua
+++ b/mjomatic.lua
@@ -10,37 +10,24 @@
 local mjomatic = {}
 
 local alert = require 'mjolnir.alert'
-local appfinder = require 'mjolnir.cmsj.appfinder'
-local screen = require 'mjolnir.screen'
+local grille = require 'mjolnir.grille'
 
 alert.show('mjomatic loaded')
 
 local gridh
 local gridw
 
-local function resizetogrid(window, coords)
-    -- alert.show(string.format('move window %q to %d,%d-%d,%d', window:title(), coords.r1, coords.c1, coords.r2, coords.c2), 20)
+local function resizetogrid(title, coords)
+    -- print(string.format('move window %q to %d,%d-%d,%d', title, coords.r1, coords.c1, coords.r2, coords.c2), 20)
 
-    -- collect screen dimensions
-    local frame = screen.mainscreen():fullframe()
-    local framew = screen.mainscreen():frame()
+    local grid = grille.new(gridw, gridh)
 
-    local h = framew.h
-    local w = frame.w
-    local x = framew.x
-    local y = framew.y
-    -- alert.show(string.format('screen dimensions %d,%d at %d,%d', h, w, x, y))
-    local hdelta = h / gridh
-    local wdelta = w / gridw
-
-    -- alert.show('hdelta='..hdelta, 5)
-    -- alert.show('wdelta='..wdelta, 5)
-    local newframe = {}
-    newframe.x = (coords.c1-1) * wdelta + x
-    newframe.y = (coords.r1-1) * hdelta + y
-    newframe.h = (coords.r2-coords.r1+1) * hdelta
-    newframe.w = (coords.c2-coords.c1+1) * wdelta
-    window:setframe(newframe)
+    grid:window(title):
+         xpos(coords.c1-1):
+         ypos(coords.r1-1):
+         wide(coords.c2-coords.c1+1):
+         tall(coords.r2-coords.r1+1):
+         act()()
     -- alert.show(string.format('new frame for %q is %d*%d at %d,%d', window:title(), newframe.w, newframe.h, newframe.x, newframe.y), 20)
 end
 
@@ -140,14 +127,7 @@ function mjomatic.go(cfg)
         if not windows[key] then
             error(string.format('no window found for application %s (%s)', title, key))
         end
-        local app = appfinder.app_from_name(title)
-        local window = app:mainwindow()
-        -- alert.show(string.format('application title for %q is %q, main window %q', title, app:title(), window:title()))
-        if window then
-            resizetogrid(window, windows[key])
-        else
-            alert.show(string.format('application %s has no main window', app:title()))
-        end
+        resizetogrid(title, windows[key])
     end
 end
 

--- a/spec/mjomatic_spec.lua
+++ b/spec/mjomatic_spec.lua
@@ -6,69 +6,51 @@ describe("mjomatic", function()
     setup(function()
         results = {}
 
-        -- window class
-        local window = {}
-        window.__index = window
-        function window.new(name)
-            local self = setmetatable({}, window)
-            self.name = name
-            return self
-        end
-
-        function window:setframe(frame)
-            results[self.name] = frame
-        end
-
-        package.loaded['mjolnir.window'] = window
-
-        -- application class
-        local application = {}
-        application.__index = application
-        function application.new(name)
-            local self = setmetatable({}, application)
-            self.name = name
-            return self
-        end
-
-        function application:mainwindow()
-            return window.new(self.name)
-        end
-
-        package.loaded['mjolnir.application'] = application
-
         -- appfinder module
-        local appfinder = {}
-        function appfinder.app_from_name(name)
-            return application.new(name)
-        end
-
-        package.loaded['mjolnir.cmsj.appfinder'] = appfinder
-        
-        -- screen class
-        local screen = {}
-        screen.__index = screen
-        function screen.new(name, frame, framew)
-            local self = setmetatable({}, screen)
-            self.name = name
-            self.framefull = frame
-            self.framew = framew
+        local grille = {}
+	grille.__index = grille
+        function grille.new(gw, gh)
+            local self = setmetatable({}, grille)
+            self.mainscreen = {h=1200, w=1920, x=0, y=0}
+            self.mainscreen_frame = {h=1178, w=1916, x=0, y=22}
+            self.gw = gw
+            self.gh = gh
+	    self.cw = self.mainscreen.w/gw
+	    self.ch = (self.mainscreen.h - self.mainscreen_frame.y)/gh
             return self
         end
 
-        function screen.mainscreen()
-            return screen.new('mainscreen', {h=1200, w=1920, x=0, y=0}, {h=1178, w=1916, x=0, y=22})
-        end
+	function grille:window(title)
+	   self.title = title
+	   return self
+	end
 
-        function screen:fullframe()
-            return self.framefull
-        end
+	function grille:xpos(x)
+	   self.x = x * self.cw + self.mainscreen_frame.x
+	   return self
+	end
 
-        function screen:frame()
-            return self.framew
-        end
+	function grille:ypos(y)
+	   self.y = y * self.ch + self.mainscreen_frame.y
+	   return self
+	end
 
-        package.loaded['mjolnir.screen'] = screen
+	function grille:wide(w)
+	   self.w = w * self.cw
+	   return self
+	end
 
+	function grille:tall(h)
+	   self.h = h * self.ch
+	   return self
+	end
+
+	function grille:act()
+	   results[self.title] = {x=self.x, y=self.y, w=self.w, h=self.h}
+	   return function () end
+	end
+
+        package.loaded['mjolnir.grille'] = grille
 
         -- alert class
         local alert = {}
@@ -77,10 +59,7 @@ describe("mjomatic", function()
     end)
 
     teardown(function()
-        package.loaded['mjolnir.window'] = nil
-        package.loaded['mjolnir.application'] = nil
-        package.loaded['mjolnir.cmsj.appfinder'] = nil
-        package.loaded['mjolnir.screen'] = nil
+        package.loaded['mjolnir.grille'] = nil
         package.loaded['mjolnir.alert'] = nil
     end)
 
@@ -102,9 +81,10 @@ describe("mjomatic", function()
             "i iTerm",
             "Y YoruFukurou",
             "S Sublime Text 2"})
-        assert.are.same(results, {['iTerm']={ x=1040, w=880, h=706.8, y=22 },
-                                  ['Google Chrome'] = { x=0, w=1040, h=471.2, y=22 },
-                                  ['Sublime Text 2'] = { x=0, w=1040, h=706.8, y=493.2 },
-                                  ['YoruFukurou'] = { x=1040, w=880, h=471.2, y=728.8 } }) 
+	local expected = {['iTerm']={ x=1040, w=880, h=706.8, y=22 },
+                          ['Google Chrome'] = { x=0, w=1040, h=471.2, y=22 },
+                          ['Sublime Text 2'] = { x=0, w=1040, h=706.8, y=493.2 },
+                          ['YoruFukurou'] = { x=1040, w=880, h=471.2, y=728.8 } }
+        assert.are.same(expected, results)
     end)
 end)


### PR DESCRIPTION
[mjolnir.grille](https://github.com/knl/mjolnir.grille) is a grid module that supports fluent interface and multiple grids at the same time.

It seemed as a good approach to re-use its capabilities for doing grid layouts and let mjomatic focus on other aspects.
